### PR TITLE
Fix jextract executable search logic on Windows

### DIFF
--- a/src/main/kotlin/io/github/krakowski/jextract/JextractTask.kt
+++ b/src/main/kotlin/io/github/krakowski/jextract/JextractTask.kt
@@ -7,6 +7,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.kotlin.dsl.newInstance
 import org.gradle.kotlin.dsl.property
 import java.nio.file.Files
@@ -43,7 +44,11 @@ abstract class JextractTask : DefaultTask() {
 
         // Check if jextract is present
         val javaPath = toolchain.get()
-        val jextractBinary = Paths.get(javaPath, "bin/jextract")
+        val jextractBinary = if (OperatingSystem.current().isWindows) {
+            Paths.get(javaPath, "bin/jextract.exe")
+        } else {
+            Paths.get(javaPath, "bin/jextract")
+        }
         if (Files.notExists(jextractBinary)) {
             throw GradleException("jextract binary could not be found at ${jextractBinary}")
         }


### PR DESCRIPTION
Currently, this plugin only seems to search for the JExtract executable with a path of `bin/jextract`. However, this doesn't work on Windows since Windows executables also have a `.exe` extension.

This PR adds in a bit of extra logic to detect if the buildsystem is Windows, and if so, look for `bin/jextract.exe` instead of just `bin/jextract`.

Also thanks for making this plugin!