### PR TITLE
Fix retrieving jextract executable from PATH 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,10 @@ dependencies {
 
     // Use the Kotlin JDK 8 standard library
     implementation(kotlin("stdlib-jdk8"))
+
+    // Gradle test kit using JUnit
+    testImplementation(gradleTestKit())
+    testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
 }
 
 java {
@@ -61,4 +65,8 @@ pluginBundle {
 
 tasks.withType<Wrapper> {
     gradleVersion = "7.4"
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
 }

--- a/src/main/kotlin/io/github/krakowski/jextract/JextractTask.kt
+++ b/src/main/kotlin/io/github/krakowski/jextract/JextractTask.kt
@@ -14,7 +14,6 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.util.regex.Pattern
 
 abstract class JextractTask : DefaultTask() {
 
@@ -49,14 +48,9 @@ abstract class JextractTask : DefaultTask() {
         val executable = if (operatingSystem.isWindows) WINDOWS_EXECUTABLE else UNIX_EXECUTABLE
 
         // Search for jextract in PATH
-        val pathExecutable = System.getenv(ENV_PATH)
-                .split(Pattern.quote(File.pathSeparator)).stream()
-                .map { Paths.get(it, executable) }
-                .filter { Files.exists(it) }
-                .findFirst()
-
-        if (pathExecutable.isPresent) {
-            return pathExecutable.get()
+        System.getenv(ENV_PATH).split(File.pathSeparator).forEach { pathEntry ->
+            val exPath = Paths.get(pathEntry, executable)
+            if (Files.exists(exPath)) return@findExecutable exPath
         }
 
         // Use bundled jextract binary as a fallback
@@ -173,7 +167,6 @@ abstract class JextractTask : DefaultTask() {
     }
 
     private companion object {
-
         const val ENV_PATH = "PATH"
         const val UNIX_EXECUTABLE = "jextract"
         const val WINDOWS_EXECUTABLE = "jextract.exe"

--- a/src/test/kotlin/io/github/krakowski/jextract/JextractPluginFunctionalTest.kt
+++ b/src/test/kotlin/io/github/krakowski/jextract/JextractPluginFunctionalTest.kt
@@ -1,0 +1,46 @@
+package io.github.krakowski.jextract
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class JextractPluginFunctionalTest {
+    @TempDir
+    private lateinit var testProjectDir: File
+
+    private lateinit var settingsFile: File
+
+    private lateinit var buildFile: File
+
+    @BeforeEach
+    fun setup() {
+        settingsFile = File(testProjectDir, "settings.gradle").apply {
+            writeText("""
+                rootProject.name = 'jextract-sample'
+            """.trimIndent())
+        }
+        buildFile = File(testProjectDir, "build.gradle").apply {
+            writeText("""
+            plugins {
+                id 'io.github.krakowski.jextract'
+            }    
+            """.trimIndent())
+        }
+    }
+
+    @Test
+    fun `test whether jextract task succeeds`() {
+        val result = GradleRunner.create()
+            // can be enabled for debugging, alternatively set `org.gradle.testkit.debug` System property to `true`
+//            .withDebug(true)
+            .withProjectDir(testProjectDir)
+            .withArguments("jextract")
+            .withPluginClasspath()
+            .build()
+        assertEquals(TaskOutcome.SUCCESS, result.task(":jextract")?.outcome)
+    }
+}


### PR DESCRIPTION
Also adds a functional test which can be used for debugging and changes code to use Kotlin FP idioms instead of Java streams.

Fixes #8