### PR TITLE
Add definedMacros option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The `jextract` task exposes the following configuration options.
 |    `typedefs`    |       `java.lang.String[]`      |                | Whitelist of typedef symbols                                               |
 |     `unions`     |       `java.lang.String[]`      |                | Whitelist of union symbols                                                 |
 |    `variables`   |       `java.lang.String[]`      |                | Whitelist of global variable symbols                                       |
+|  `definedMacros` |       `java.lang.String[]`      |                | List of additional defined C preprocessor macros                           |
 |   `sourceMode`   |       `java.lang.Boolean`       |                | Generate source files instead of class files (default: `true`)             |
 |    `outputDir`   | `org.gradle.api.file.Directory` |                | The output directory under which the generated source files will be placed |
 

--- a/src/main/kotlin/io/github/krakowski/jextract/JextractTask.kt
+++ b/src/main/kotlin/io/github/krakowski/jextract/JextractTask.kt
@@ -138,6 +138,12 @@ abstract class JextractTask : DefaultTask() {
                 arguments += it
             }
 
+            // Include specified preprocessor macros
+            definition.definedMacros.orNull?.forEach {
+                arguments += "-D"
+                arguments += it
+            }
+
             // Add include paths if they are present
             definition.includes.orNull?.forEach {
                 arguments += "-I"

--- a/src/main/kotlin/io/github/krakowski/jextract/LibraryDefinition.kt
+++ b/src/main/kotlin/io/github/krakowski/jextract/LibraryDefinition.kt
@@ -52,4 +52,8 @@ abstract class LibraryDefinition {
     /** Whitelist of global variables. */
     @get:Optional @get:Input
     abstract val variables: ListProperty<String>
+
+    /** List of additional defined C preprocessor macros. */
+    @get:Optional @get:Input
+    abstract val definedMacros: ListProperty<String>
 }


### PR DESCRIPTION
`jextract` supports an option to define a C preprocessor macro from the command line:
```    
-D <macro>                     define a C preprocessor macro    
```
Note that this is separate from `--include-macro <name>`, which seems to do something else. This pull requests adds the `-D` functionality under a `definedMacros` property in the LibraryDefinition.