### PR TITLE
Add jextractBinary option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ jextract {
     header("${project.projectDir}/src/main/c/stdio.h") {
         // The library name
         libraries = [ 'stdc++' ]
-    
+
         // The package under which all source files will be generated
         targetPackage = 'org.unix'
-        
+
         // The generated class name
         className = 'Linux'
     }
@@ -58,27 +58,28 @@ The plugin will first try to find `jextract` inside `PATH` and then fall back to
 
 The `jextract` task exposes the following configuration options.
 
-|          Name          |               Type              |    Required    | Description                                                                |
-|:----------------------:|:-------------------------------:|:--------------:|----------------------------------------------------------------------------|
-|      `libraries`       |       `java.lang.String[]`      |                | The libraries against which the native code will link                      |
-|       `includes`       |       `java.lang.String[]`      |                | A list of directories which should be included during code generation      |
-|    `targetPackage`     |        `java.lang.String`       | :black_circle: | The package under which all bindings will be generated                     |
-|      `className`       |        `java.lang.String`       |                | The generated class file's name                                            |
-|      `functions`       |       `java.lang.String[]`      |                | Whitelist of function symbols                                              |
-|      `constants`       |       `java.lang.String[]`      |                | Whitelist of macro and enum constant symbols                               |
-|       `structs`        |       `java.lang.String[]`      |                | Whitelist of struct symbols                                                |
-|       `typedefs`       |       `java.lang.String[]`      |                | Whitelist of typedef symbols                                               |
-|        `unions`        |       `java.lang.String[]`      |                | Whitelist of union symbols                                                 |
-|      `variables`       |       `java.lang.String[]`      |                | Whitelist of global variable symbols                                       |
-|    `definedMacros`     |       `java.lang.String[]`      |                | List of additional defined C preprocessor macros                           |
-| `useSystemLoadLibrary` |       `java.lang.Boolean`       |                | Load libraries into the loader symbol lookup                               |
-|      `outputDir`       | `org.gradle.api.file.Directory` |                | The output directory under which the generated source files will be placed |
+|          Name          |               Type                |    Required    | Description                                                                |
+|:----------------------:|:---------------------------------:|:--------------:|----------------------------------------------------------------------------|
+|      `libraries`       |       `java.lang.String[]`        |                | The libraries against which the native code will link                      |
+|       `includes`       |       `java.lang.String[]`        |                | A list of directories which should be included during code generation      |
+|    `targetPackage`     |        `java.lang.String`         | :black_circle: | The package under which all bindings will be generated                     |
+|      `className`       |        `java.lang.String`         |                | The generated class file's name                                            |
+|      `functions`       |       `java.lang.String[]`        |                | Whitelist of function symbols                                              |
+|      `constants`       |       `java.lang.String[]`        |                | Whitelist of macro and enum constant symbols                               |
+|       `structs`        |       `java.lang.String[]`        |                | Whitelist of struct symbols                                                |
+|       `typedefs`       |       `java.lang.String[]`        |                | Whitelist of typedef symbols                                               |
+|        `unions`        |       `java.lang.String[]`        |                | Whitelist of union symbols                                                 |
+|      `variables`       |       `java.lang.String[]`        |                | Whitelist of global variable symbols                                       |
+|    `definedMacros`     |       `java.lang.String[]`        |                | List of additional defined C preprocessor macros                           |
+| `useSystemLoadLibrary` |       `java.lang.Boolean`         |                | Load libraries into the loader symbol lookup                               |
+|      `outputDir`       | `org.gradle.api.file.Directory`   |                | The output directory under which the generated source files will be placed |
+|    `jextractBinary`    | `org.gradle.api.file.RegularFile` |                | The jextract binary to be used                                             |
 
 ## :wrench: &nbsp; Requirements
 
   * [OpenJDK 22](https://openjdk.org/projects/jdk/22/)
   * [Project Jextract](https://jdk.java.net/jextract/)
-  
+
 ## :scroll: &nbsp; License
 
 This project is licensed under the GNU GPLv3 License - see the [LICENSE](LICENSE) file for details.

--- a/src/main/kotlin/io/github/krakowski/jextract/LibraryDefinition.kt
+++ b/src/main/kotlin/io/github/krakowski/jextract/LibraryDefinition.kt
@@ -2,6 +2,7 @@ package io.github.krakowski.jextract
 
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
@@ -60,4 +61,8 @@ abstract class LibraryDefinition {
     /** List of additional defined C preprocessor macros. */
     @get:Optional @get:Input
     abstract val definedMacros: ListProperty<String>
+
+    /** The jextract binary to be used. */
+    @get:Optional @get:InputFile
+    abstract val jextractBinary: RegularFileProperty
 }


### PR DESCRIPTION
Adds the `jextractBinary` optional file option, allowing users to specify a custom location for the binary to be used instead of the system binary.